### PR TITLE
stextools.__version__ for version introspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *~
 auto
 *.swp
+*.venv

--- a/stextools/__init__.py
+++ b/stextools/__init__.py
@@ -1,6 +1,8 @@
+import importlib.metadata
 from stextools.pythonapi import setup_logging, interactive_symbol_search
-
+__version__ = importlib.metadata.version('stextools')
 __all__ = [
     'setup_logging',
     'interactive_symbol_search',
+    '__version__'
 ]

--- a/stextools/core/cache.py
+++ b/stextools/core/cache.py
@@ -23,14 +23,9 @@ class Cache:
     @classmethod
     @functools.cache
     def get_stextools_version(cls) -> str:
-        """For now, we will use the last modification time of the stextools package.
-
-        We could also use the git hash, but that would require that the package is installed from git.
-        In the future, a version number should be used."""
-        last_modified = -math.inf
-        for file in Path(__file__).parent.rglob('**/*.py'):
-            last_modified = max(last_modified, file.stat().st_mtime)
-        return str(last_modified)
+        """Returns the version number of the presently installed stextools"""
+        from stextools import __version__
+        return __version__
 
     @classmethod
     def get_mathhub(cls, update_all: bool = False) -> MathHub:


### PR DESCRIPTION
The `stextools/__init__.py` file now defines the `__version__` dunder that can be imported from anywhere for version introspection.  
``` python
from stextools import __version__
print(__version__)  # the version appearing in the pyproject.toml
```

In this commit, the `stextools.core.cache.Cache.get_stextools_version` method now makes use of this `__version__` introspection.

This commit also gitignores venv directories